### PR TITLE
ci: update node version to 16 and go to 1.19

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
         with:
-          go-version: ^1.16
+          go-version: ^1.19
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # See: https://goreleaser.com/ci/actions/
 

--- a/.github/workflows/test_push_pr.yml
+++ b/.github/workflows/test_push_pr.yml
@@ -6,13 +6,13 @@ jobs:
     name: Run test suite
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
         with:
-          go-version: ^1.16
+          go-version: ^1.19
 
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build application
         env:


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/